### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/eriktaubeneck/foundry.svg?branch=master)](https://travis-ci.org/eriktaubeneck/foundry)
 [![Coverage Status](https://img.shields.io/coveralls/eriktaubeneck/foundry.svg)](https://coveralls.io/r/eriktaubeneck/foundry)
-[![Latest Version](https://pypip.in/version/foundry/badge.png)](https://pypi.python.org/pypi/foundry/)
-[![Downloads](https://pypip.in/download/foundry/badge.png)](https://pypi.python.org/pypi/foundry/)
-[![License](https://pypip.in/license/foundry/badge.png)](https://pypi.python.org/pypi/foundry/)
+[![Latest Version](https://img.shields.io/pypi/v/foundry.svg)](https://pypi.python.org/pypi/foundry/)
+[![Downloads](https://img.shields.io/pypi/dm/foundry.svg)](https://pypi.python.org/pypi/foundry/)
+[![License](https://img.shields.io/pypi/l/foundry.svg)](https://pypi.python.org/pypi/foundry/)
 
 Often times, when building an application, it is handy to create some seed data with which to use and test how parts of your application will work. When this dataset is small, a python script works just fine, but as that data set (and number of different data models) grow, this approach becomes quite cumbersome.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20foundry))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `foundry`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.